### PR TITLE
Avoid marshal dumping raw data or compressed string.

### DIFF
--- a/lib/active_support/cache/memcached_snappy_store.rb
+++ b/lib/active_support/cache/memcached_snappy_store.rb
@@ -17,28 +17,28 @@ module ActiveSupport
         # normally unless_exist would make this method use add,  add will not make sense on compressed entries
         raise UnsupportedOperation.new("unless_exist would try to use the unsupported add method") if options && options[:unless_exist]
 
-        value = options[:raw] ? entry.value.to_s : entry
+        serialized_value = options[:raw] ? entry.value.to_s : Marshal.dump(entry)
         expires_in = options[:expires_in].to_i
         if expires_in > 0 && !options[:raw]
           # Set the memcache expire a few minutes in the future to support race condition ttls on read
           expires_in += 5.minutes
         end
 
-        serialized_value = Marshal.dump(value)
         serialized_compressed_value = Snappy.deflate(serialized_value)
 
-        response = @data.set(escape_key(key), serialized_compressed_value, expires_in, true)
+        response = @data.set(escape_key(key), serialized_compressed_value, expires_in, false)
       end
 
+      def read_entry(key, options)
+        deserialize_entry(@data.get(escape_key(key), false))
+      end
 
-      def deserialize_entry_with_snappy(*args)
-        compressed_value = args.first
+      def deserialize_entry(compressed_value)
         decompressed_value = compressed_value.nil? ? compressed_value : Snappy.inflate(compressed_value)
-        args[0] = decompressed_value
-        deserialize_entry_without_snappy(*args)
+        super(decompressed_value)
+      rescue Snappy::Error
+        nil
       end
-
-      alias_method_chain :deserialize_entry, :snappy
     end
   end
 end


### PR DESCRIPTION
@camilo & @csfrancis for review
## Problem

The cache entry is normally marshal dumped to serialize the object, but the `:raw => true` option should avoid this `Marshal.dump` so that a string can be cached directly.

After this we compress the data using Snappy, then we have a string we can write to memcache.  However, instead passed `true` to the `marshal` parameter in the `@data.set` method call, which does another unnecessary `Marshal.dump` of the compressed string.
## Solution

This pull request gets rid of the above mentioned unnecessary marshalling.

This PR also overrides read_entry in order to pass `false` for the marshal parameter of `@data.get` to avoid an unnecessary `Marshal.load`.  The `rescue Snappy::Error` is temporarily needed until we flush the cache.

We aren't currently using the `:raw => true` option when writing to the cache, so no transitional code is needed for that purpose.
