### PR TITLE
dont lock to activesupport 3.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rails_cache_adapters (0.0.1)
-      activesupport (~> 3.2.12)
+      activesupport
       snappy (= 0.0.4)
 
 GEM
@@ -18,7 +18,7 @@ GEM
     minitest (4.7.1)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
-    multi_json (1.7.2)
+    multi_json (1.8.2)
     rake (10.0.4)
     snappy (0.0.4)
     timecop (0.6.1)

--- a/rails_cache_adapters.gemspec
+++ b/rails_cache_adapters.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.name          = "rails_cache_adapters"
   gem.require_paths = ["lib"]
   gem.version       = '0.0.1'
-  gem.add_runtime_dependency "activesupport", "~>3.2.12"
+  gem.add_runtime_dependency "activesupport", ">=  3.1"
   gem.add_runtime_dependency "snappy", "0.0.4"
   gem.add_development_dependency "i18n"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
@camilo @boourns @arthurnn  

It looks like our dependency on AS here is just to extend it with MemcachedSnappyStore. I'm not seeing anything that should force us to depend on the 3.x branch, correct?
