### PR TITLE
Dont snappy.inflate when is false

### DIFF
--- a/lib/active_support/cache/memcached_snappy_store.rb
+++ b/lib/active_support/cache/memcached_snappy_store.rb
@@ -33,8 +33,11 @@ module ActiveSupport
       end
 
       def deserialize_entry(compressed_value)
-        decompressed_value = compressed_value.nil? ? compressed_value : Snappy.inflate(compressed_value)
-        super(decompressed_value)
+        if compressed_value
+          super(Snappy.inflate(compressed_value))
+        else
+          nil
+        end
       end
     end
   end

--- a/test/test_memcached_snappy_store.rb
+++ b/test/test_memcached_snappy_store.rb
@@ -61,6 +61,12 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
     assert_nil @cache.read(key)
   end
 
+  test "get should work when there is a connection fail" do
+    key = 'ponies2'
+    @cache.instance_variable_get(:@data).expects(:check_return_code).raises(Memcached::ConnectionFailure).at_least_once
+    assert_nil @cache.read(key)
+  end
+
   test "should use snappy to multi read cache entries but not on missing entries" do
     keys = %w{ one tow three }
     values = keys.map{ |k| k * 10 }


### PR DESCRIPTION
When server is off, memcached raises a `Memcached::ConnectionFailure` and return false.
Snappy.inflate was having troubles to inflate a `false`. So we should check if is `nil` OR `false` before inflating.

review @camilo @jduff 

this should fix:

```
Exception in Shopify: TypeError: no implicit conversion of false into String occurred 10 time(s):
```
