### PR TITLE
Allow add in MemcachedSnappyStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ActiveSupport memcached store. This wraps the memcached gem into a ActiveSupport
 
 ### MemcachedSnappyStore
 
-ActiveSupport cache store that adds snappy compression at the cost of making the ```incr, decr, add``` operations unavailable. 
+ActiveSupport cache store that adds snappy compression at the cost of making the ```incr, decr``` operations unavailable.
 
 ## Installation
 
@@ -39,8 +39,8 @@ In your environment file:
 config.cache_store = :memcached_store,
 
 # for snappy store
-config.cache_store = :memcached_snappy_store,  
-  Memcached::Rails.new(:servers => ['memcached1.foo.com', 'memcached2.foo.com']) 
+config.cache_store = :memcached_snappy_store,
+  Memcached::Rails.new(:servers => ['memcached1.foo.com', 'memcached2.foo.com'])
 ```
 
 ## Code status

--- a/lib/active_support/cache/memcached_snappy_store.rb
+++ b/lib/active_support/cache/memcached_snappy_store.rb
@@ -20,22 +20,11 @@ module ActiveSupport
         raise UnsupportedOperation.new("decrement is not supported by: #{self.class.name}")
       end
 
-      protected
-
-      def write_entry(key, entry, options)
-        # normally unless_exist would make this method use add,  add will not make sense on compressed entries
-        raise UnsupportedOperation.new("unless_exist would try to use the unsupported add method") if options && options[:unless_exist]
-
-        serialized_value = options[:raw] ? entry.value.to_s : Marshal.dump(entry)
-        expires_in = options[:expires_in].to_i
-        if expires_in > 0 && !options[:raw]
-          # Set the memcache expire a few minutes in the future to support race condition ttls on read
-          expires_in += 5.minutes
-        end
-
-        serialized_compressed_value = Snappy.deflate(serialized_value)
-
-        @data.set(escape_key(key), serialized_compressed_value, expires_in, true)
+      private
+      def serialize_entry(entry, options)
+        value = options[:raw] ? entry.value.to_s : Marshal.dump(entry)
+        options[:raw] = true
+        Snappy.deflate(value)
       end
 
       def deserialize_entry(compressed_value)

--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -106,12 +106,12 @@ module ActiveSupport
 
         def write_entry(key, entry, options) # :nodoc:
           method = options && options[:unless_exist] ? :add : :set
-          value = options[:raw] ? entry.value.to_s : entry
           expires_in = options[:expires_in].to_i
           if expires_in > 0 && !options[:raw]
             # Set the memcache expire a few minutes in the future to support race condition ttls on read
             expires_in += 5.minutes
           end
+          value = serialize_entry(entry, options)
           @data.send(method, escape_key(key), value, expires_in, options[:raw])
         rescue *NONFATAL_EXCEPTIONS => e
           @data.log_exception(e)
@@ -143,6 +143,11 @@ module ActiveSupport
           else
             nil
           end
+        end
+
+        def serialize_entry(entry, options)
+          entry = entry.value.to_s if options[:raw]
+          entry
         end
 
     end

--- a/test/test_memcached_snappy_store.rb
+++ b/test/test_memcached_snappy_store.rb
@@ -19,8 +19,8 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
     end
   end
 
-  test "write should not allow  the implicit add operation when unless_exist is passed to write" do
-    assert_raise(ActiveSupport::Cache::MemcachedSnappyStore::UnsupportedOperation) do
+  test "write should allow  the implicit add operation when unless_exist is passed to write" do
+    assert_nothing_raised(ActiveSupport::Cache::MemcachedSnappyStore::UnsupportedOperation) do
       @cache.write('foo', 'bar', :unless_exist => true)
     end
   end


### PR DESCRIPTION
`add` is erroneously :no_good::hammer: in `MemcachedSnappyStore`.

This refactors `MemcachedStore.write_entry` with a `serialize_entry` helper, and removes the `add` :no_good::hammer:.

@camilo for review.
