### PR TITLE
Bump memcached to 1.8.0

### DIFF
--- a/lib/memcached_store/version.rb
+++ b/lib/memcached_store/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module MemcachedStore
-  VERSION = "0.11.2"
+  VERSION = "0.11.3"
 end

--- a/memcached_store.gemspec
+++ b/memcached_store.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = MemcachedStore::VERSION
   gem.add_runtime_dependency "activesupport", ">=  3.2"
-  gem.add_runtime_dependency "memcached", "~> 1.7.2"
+  gem.add_runtime_dependency "memcached", "~> 1.8.0"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "minitest"


### PR DESCRIPTION
1.8.0 of the memcached gem has been released. We need it for #14. Bumping to check it works without #14.

@arthurnn, @camilo  for review
