### PR TITLE
Make CAS play nice with Snappy

### DIFF
--- a/lib/active_support/cache/memcached_snappy_store.rb
+++ b/lib/active_support/cache/memcached_snappy_store.rb
@@ -34,6 +34,10 @@ module ActiveSupport
           nil
         end
       end
+
+      def cas_raw?(options)
+        true
+      end
     end
   end
 end

--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -71,7 +71,7 @@ module ActiveSupport
         key = namespaced_key(name, options)
 
         instrument(:cas, name, options) do
-          @data.cas(key, expiration(options), options[:raw]) do |raw_value|
+          @data.cas(key, expiration(options), cas_raw?(options)) do |raw_value|
             entry = deserialize_entry(raw_value)
             value = yield entry.value
             serialize_entry(Entry.new(value, options), options)
@@ -88,7 +88,7 @@ module ActiveSupport
         keys_to_names = Hash[names.map{|name| [escape_key(namespaced_key(name, options)), name]}]
 
         instrument(:cas_multi, names, options) do
-          @data.cas(keys_to_names.keys, expiration(options), options[:raw]) do |raw_values|
+          @data.cas(keys_to_names.keys, expiration(options), cas_raw?(options)) do |raw_values|
             values = {}
             raw_values.each do |key, raw_value|
               entry = deserialize_entry(raw_value)
@@ -183,6 +183,10 @@ module ActiveSupport
         def serialize_entry(entry, options)
           entry = entry.value.to_s if options[:raw]
           entry
+        end
+
+        def cas_raw?(options)
+          options[:raw]
         end
 
         def expiration(options)

--- a/lib/memcached_store/version.rb
+++ b/lib/memcached_store/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module MemcachedStore
-  VERSION = "0.12.3"
+  VERSION = "0.12.4"
 end

--- a/test/test_memcached_snappy_store.rb
+++ b/test/test_memcached_snappy_store.rb
@@ -109,13 +109,56 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
       assert_equal entry_value, v
       update_value
     end
-    assert_equal update_value, result
+    assert result
     assert_equal update_value, @cache.read(key)
 
     actual_cache_value = @cache.instance_variable_get(:@data).get(key, true)
     serialized_entry = Snappy.inflate(actual_cache_value)
     entry = Marshal.load(serialized_entry)
-    assert entry.is_a?(Entry)
+    assert entry.is_a?(ActiveSupport::Cache::Entry)
     assert_equal update_value, entry.value
+  end
+
+  test "cas should support raw entries that don't use marshal format" do
+    key = 'key'
+    @cache.write(key, 'value', :raw => true)
+    result = @cache.cas(key, :raw => true) do |v|
+      assert_equal 'value', v
+      'new_value'
+    end
+    assert result
+    actual_cache_value = @cache.instance_variable_get(:@data).get(key, true)
+    assert_equal 'new_value', Snappy.inflate(actual_cache_value)
+  end
+
+  test "cas_multi should use snappy to read and write cache entries" do
+    keys = %w{ one two three }
+    values = keys.map{ |k| k * 10 }
+    update_hash = {"two" => "two" * 11}
+
+    keys.zip(values) { |k, v| @cache.write(k, v) }
+
+    result = @cache.cas_multi(*keys) do |hash|
+      assert_equal Hash[keys.zip(values)], hash
+      update_hash
+    end
+    assert result
+    assert_equal Hash[keys.zip(values)].merge(update_hash), @cache.read_multi(*keys)
+  end
+
+  test "cas_multi should support raw entries that don't use marshal format" do
+    keys = %w{ one two three }
+    values = keys.map{ |k| k * 10 }
+    update_hash = {"two" => "two" * 11}
+
+    keys.zip(values) { |k, v| @cache.write(k, v) }
+
+    result = @cache.cas_multi(*keys, :raw => true) do |hash|
+      assert_equal Hash[keys.zip(values)], hash
+      update_hash
+    end
+    assert result
+    actual_cache_value = @cache.instance_variable_get(:@data).get("two", true)
+    assert_equal update_hash["two"], Snappy.inflate(actual_cache_value)
   end
 end


### PR DESCRIPTION
`cas` doesn't play nicely with `MemcachedSnappyStore` because `add` always sidesteps the `Memcached` codec, while `cas` honours the `:raw` option.

This adds tests for `cas` and `cas_multi` with `MemcachedSnappyStore`, with and without `:raw => true`.

It fixes the problem by adding a `cas_raw?` method to `MemcachedStore` that returns `options[:raw]`. `MemcachedSnappyStore` overrides `cas_raw?` to return true.

`cas_raw?` is used to compute the `raw` argument to `cas` and `cas_multi`, while `options` is passed unfettered to `serialize_entry` within the `cas` and `cas_multi` blocks.

@camilo @arthurnn for review. /cc @Shopify/webscale 
