### PR TITLE
Add public reset 

### DIFF
--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -135,6 +135,13 @@ module ActiveSupport
         !!super
       end
 
+      def reset #:nodoc:
+        @data.reset
+      rescue *NONFATAL_EXCEPTIONS => e
+        @data.log_exception(e)
+        false
+      end
+
       protected
         def read_entry(key, options) # :nodoc:
           deserialize_entry(@data.get(escape_key(key), true))

--- a/test/test_memcached_store.rb
+++ b/test/test_memcached_store.rb
@@ -388,6 +388,12 @@ class TestMemcachedStore < ActiveSupport::TestCase
     assert_equal "", client.prefix_key, "should not send the namespace to the client"
     assert_equal "foo::key", cache.send(:namespaced_key, "key", cache.options)
   end
+  
+  def test_reset
+    client = @cache.instance_variable_get(:@data)
+    client.expects(:reset).once
+    @cache.reset
+  end
 
   private
 


### PR DESCRIPTION
@arthurnn @fbogsany , cc: @jnormore 

When using web servers which share memory and use copy-on-write, you have to do watch out for things like that https://www.phusionpassenger.com/documentation/Users%20guide%20Nginx.html#_example_1_memcached_connection_sharing_harmful

dalli_store supports `Rails.cache.reset` , but if you want to do this with memcached_store, you have to do `Rails.cache.instance_variable_get(:@data).reset` and it makes me :cry: 

This simple PR makes reset public
