### PR TITLE
log: default to rails

### DIFF
--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -48,6 +48,11 @@ module ActiveSupport
         extend Strategy::LocalCache
       end
 
+      def logger
+        return @logger if @logger
+        @logger = ::Rails.logger if defined?(::Rails)
+      end
+
       def write(*args)
         return true if read_only
         super(*args)

--- a/lib/memcached_store/memcached_safety.rb
+++ b/lib/memcached_store/memcached_safety.rb
@@ -71,12 +71,16 @@ module MemcachedStore
       ENV
     end
 
+    def logger
+      return @logger if @logger
+      @logger = ::Rails.logger if defined?(::Rails)
+    end
 
     private
 
     def report_exception(exception)
       if defined?(::Rails)
-        Rails.logger.error "[#{self.class}] exception=#{exception}"
+        logger.error "[#{self.class}] exception=#{exception}"
       end
       nil # make sure return value is nil
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,3 +5,17 @@ require 'timecop'
 require 'active_support/test_case'
 
 require 'memcached_store'
+
+class Rails
+  def self.logger
+    @logger ||= Logger.new("/dev/null")
+  end
+
+  def self.env
+    Struct.new("Env") do
+      def self.test?
+        true
+      end
+    end
+  end
+end

--- a/test/test_memcached_safety.rb
+++ b/test/test_memcached_safety.rb
@@ -125,6 +125,11 @@ class TestMemcachedSafety < ActiveSupport::TestCase
       @cache.prepend("a-key", "other")
     end
   end
+
+  test "logger defaults to rails logger" do
+    assert_equal Rails.logger, @cache.logger
+  end
+
   private
 
   def expect_nonfatal(sym)

--- a/test/test_memcached_store.rb
+++ b/test/test_memcached_store.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'logger'
 
 class TestMemcachedStore < ActiveSupport::TestCase
   setup do
@@ -581,6 +582,10 @@ class TestMemcachedStore < ActiveSupport::TestCase
 
     assert_equal "yes", @cache.fetch("walrus")
     assert_equal "yes", @cache.fetch("narwhal")
+  end
+
+  def test_logger_defaults_to_rails_logger
+    assert_equal Rails.logger, @cache.logger
   end
 
   private


### PR DESCRIPTION
@fbogsany instead of requiring overriding this for Rails, let's default to a sane default. We already have a bunch of `defined?(::Rails)` in here and this helps me tremendously to simplify our configuration.