### PR TITLE
Remove support to ruby older than 2.2 and Rails 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,12 @@ services: memcache
 before_install:
   - gem update bundler
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.10
   - 2.2.6
   - 2.3.3
 env:
-  - "AS_VERSION=3.2.18"
   - "AS_VERSION=4.0.5"
   - "AS_VERSION=4.1.0"
-matrix:
-  allow_failures:
-    - env: "AS_VERSION=4.1.0"
-  exclude:
-    - env: "AS_VERSION=3.2.18"
-      rvm: 2.2.6
-    - env: "AS_VERSION=3.2.18"
-      rvm: 2.3.3
+  - "AS_VERSION=4.2.0"
+  - "AS_VERSION=5.0.0"
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in rails_cache_adapters.gemspec
 gemspec
 
-version = ENV["AS_VERSION"] || "4.0.5"
+version = ENV["AS_VERSION"] || "5.0.0"
 as_version = case version
 when "master"
   { github: "rails/rails" }
@@ -14,7 +14,6 @@ end
 gem "activesupport", as_version
 
 group :test do
-  gem "minitest", '~> 4.0' if version == "3.2.18"
   gem "mocha"
   gem "timecop"
   gem "snappy"

--- a/memcached_store.gemspec
+++ b/memcached_store.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |gem|
   gem.files = Dir["lib/**/*.rb", "README.md", "LICENSE"]
   gem.require_paths = ["lib"]
 
+  gem.required_ruby_version = ">= 2.2.0"
+
   gem.add_runtime_dependency "activesupport", ">= 3.2"
   gem.add_runtime_dependency "memcached", "~> 1.8.0"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,10 @@ require 'minitest/autorun'
 require 'mocha/setup'
 require 'timecop'
 
+require 'active_support'
+
+ActiveSupport.test_order = :random if ActiveSupport.respond_to?(:test_order)
+
 require 'active_support/test_case'
 
 require 'memcached_store'


### PR DESCRIPTION
This will require a major bump to 1.0.0, but the API is stable now.

Ref Shopify/shopify#59229

Review @Shopify/pods @Shopify/rails5 