### PR TITLE
Rewrite the cache store to use the Rails 5 API

### DIFF
--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -152,11 +152,15 @@ module ActiveSupport
       end
 
       def clear(options = nil)
-        instrument(:clear, options) { @data.flush_all }
+        ActiveSupport::Notifications.instrument("cache_clear.active_support", options || {}) do
+          @data.flush_all
+        end
       end
 
       def stats
-        instrument(:stats) { @data.stats }
+        ActiveSupport::Notifications.instrument("cache_stats.active_support") do
+          @data.stats
+        end
       end
 
       def exist?(*)

--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -101,6 +101,8 @@ module ActiveSupport
 
       def cas_multi(*names)
         options = names.extract_options!
+        return if names.empty?
+
         options = merged_options(options)
         keys_to_names = Hash[names.map { |name| [normalize_key(name, options), name] }]
 

--- a/test/test_memcached_snappy_store.rb
+++ b/test/test_memcached_snappy_store.rb
@@ -19,7 +19,7 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
   end
 
   test "write should allow  the implicit add operation when unless_exist is passed to write" do
-    assert_nothing_raised(ActiveSupport::Cache::MemcachedSnappyStore::UnsupportedOperation) do
+    assert_nothing_raised do
       @cache.write('foo', 'bar', unless_exist: true)
     end
   end


### PR DESCRIPTION
This remove the deprecations with Rails 5 while keeping backwards compatibility with Rails 4.

Ref shopify/shopify#59229

Review @Shopify/pods @Shopify/rails5 