### PR TITLE
Fix error when passing empty set to read_multi

### DIFF
--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -64,6 +64,8 @@ module ActiveSupport
 
       def read_multi(*names)
         options = names.extract_options!
+        return {} if names.empty?
+
         options = merged_options(options)
         keys_to_names = Hash[names.map { |name| [normalize_key(name, options), name] }]
         values = {}

--- a/test/test_memcached_store.rb
+++ b/test/test_memcached_store.rb
@@ -178,6 +178,10 @@ class TestMemcachedStore < ActiveSupport::TestCase
     assert_equal({}, @cache.read_multi('foe', 'fue'))
   end
 
+  def test_read_multi_with_empty_set
+    assert_equal({}, @cache.read_multi)
+  end
+
   def test_read_and_write_compressed_small_data
     @cache.write('foo', 'bar', compress: true)
     assert_equal 'bar', @cache.read('foo')


### PR DESCRIPTION
Fixed the following error occurred when passing empty set to read_multi.

```
NoMethodError: undefined method `force_encoding' for nil:NilClass
    /home/ursm/src/github.com/Shopify/memcached_store/lib/active_support/cache/memcached_store.rb:223:in `normalize_key'
    /home/ursm/.anyenv/envs/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.2/lib/active_support/cache.rb:558:in `block in instrument'
    /home/ursm/.anyenv/envs/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.2/lib/active_support/cache.rb:567:in `log'
    /home/ursm/.anyenv/envs/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.0.2/lib/active_support/cache.rb:558:in `instrument'
    /home/ursm/src/github.com/Shopify/memcached_store/lib/active_support/cache/memcached_store.rb:71:in `read_multi'
