### PR TITLE
Enabling `Memcached::Error` instances to bubble up to caller

### DIFF
--- a/test/test_memcached_store.rb
+++ b/test/test_memcached_store.rb
@@ -394,7 +394,7 @@ class TestMemcachedStore < ActiveSupport::TestCase
     options = { namespace: 'foo:' }
     cache = ActiveSupport::Cache.lookup_store(:memcached_store, options)
     client = cache.instance_variable_get(:@data)
-    assert_equal ["127.0.0.1:11211:8"], client.servers
+    assert_equal ["127.0.0.1:11211"], extract_host_port_pairs(client.servers)
     assert_equal "", client.prefix_key, "should not send the namespace to the client"
     assert_equal "foo::key", cache.send(:namespaced_key, "key", cache.options)
   end

--- a/test/test_memcached_store.rb
+++ b/test/test_memcached_store.rb
@@ -594,6 +594,71 @@ class TestMemcachedStore < ActiveSupport::TestCase
     assert_equal Rails.logger, @cache.logger
   end
 
+  def test_constructor_set_swallow_exceptions
+    store = ActiveSupport::Cache::MemcachedStore.new([], swallow_exceptions: false)
+    refute store.swallow_exceptions
+  end
+
+  def test_read_entry_does_raise_on_error
+    raises_when_not_swallowing_exceptions do
+      @cache.read("foo")
+    end
+  end
+
+  def test_read_multi_does_raise_on_error
+    raises_when_not_swallowing_exceptions do
+      @cache.read_multi(%w(foo bar))
+    end
+  end
+
+  def test_write_entry_does_raise_on_error
+    raises_when_not_swallowing_exceptions do
+      @cache.write("foo", "bar")
+    end
+  end
+
+  def test_delete_entry_does_not_raise_on_miss
+    expect_not_found
+    @cache.swallow_exceptions = false
+    @cache.delete("foo")
+  end
+
+  def test_delete_entry_does_raise_on_error
+    raises_when_not_swallowing_exceptions do
+      @cache.delete("foo")
+    end
+  end
+
+  def test_cas_does_raise_on_error
+    raises_when_not_swallowing_exceptions do
+      @cache.cas("foo")
+    end
+  end
+
+  def test_cas_multi_does_raise_on_error
+    raises_when_not_swallowing_exceptions do
+      @cache.cas_multi(%w(foo bar))
+    end
+  end
+
+  def test_increment_does_raise_on_error
+    raises_when_not_swallowing_exceptions do
+      @cache.increment("foo")
+    end
+  end
+
+  def test_decrement_does_raise_on_error
+    raises_when_not_swallowing_exceptions do
+      @cache.decrement("foo")
+    end
+  end
+
+  def test_reset_does_raise_on_error
+    raises_when_not_swallowing_exceptions do
+      @cache.reset
+    end
+  end
+
   private
 
   def assert_notifications(pattern, num)
@@ -617,11 +682,27 @@ class TestMemcachedStore < ActiveSupport::TestCase
     client.read_only = previous
   end
 
+  def raises_when_not_swallowing_exceptions
+    expect_error
+    @cache.swallow_exceptions = false
+    assert_raise Memcached::Error do
+      yield
+    end
+  end
+
   def extract_host_port_pairs(servers)
     servers.map { |host| host.split(':')[0..1].join(':') }
   end
 
   def expect_not_found
     @cache.instance_variable_get(:@data).expects(:check_return_code).raises(Memcached::NotFound)
+  end
+
+  def expect_data_exists
+    @cache.instance_variable_get(:@data).expects(:check_return_code).raises(Memcached::ConnectionDataExists)
+  end
+
+  def expect_error
+    @cache.instance_variable_get(:@data).expects(:check_return_code).raises(Memcached::Error)
   end
 end

--- a/test/test_memcached_store.rb
+++ b/test/test_memcached_store.rb
@@ -594,25 +594,25 @@ class TestMemcachedStore < ActiveSupport::TestCase
     assert_equal Rails.logger, @cache.logger
   end
 
-  def test_constructor_set_swallow_exceptions
+  def test_constructor_sets_swallow_exceptions
     store = ActiveSupport::Cache::MemcachedStore.new([], swallow_exceptions: false)
     refute store.swallow_exceptions
   end
 
   def test_read_entry_does_raise_on_error
-    raises_when_not_swallowing_exceptions do
+    assert_raises_when_not_swallowing_exceptions do
       @cache.read("foo")
     end
   end
 
   def test_read_multi_does_raise_on_error
-    raises_when_not_swallowing_exceptions do
+    assert_raises_when_not_swallowing_exceptions do
       @cache.read_multi(%w(foo bar))
     end
   end
 
   def test_write_entry_does_raise_on_error
-    raises_when_not_swallowing_exceptions do
+    assert_raises_when_not_swallowing_exceptions do
       @cache.write("foo", "bar")
     end
   end
@@ -624,37 +624,37 @@ class TestMemcachedStore < ActiveSupport::TestCase
   end
 
   def test_delete_entry_does_raise_on_error
-    raises_when_not_swallowing_exceptions do
+    assert_raises_when_not_swallowing_exceptions do
       @cache.delete("foo")
     end
   end
 
   def test_cas_does_raise_on_error
-    raises_when_not_swallowing_exceptions do
+    assert_raises_when_not_swallowing_exceptions do
       @cache.cas("foo")
     end
   end
 
   def test_cas_multi_does_raise_on_error
-    raises_when_not_swallowing_exceptions do
+    assert_raises_when_not_swallowing_exceptions do
       @cache.cas_multi(%w(foo bar))
     end
   end
 
   def test_increment_does_raise_on_error
-    raises_when_not_swallowing_exceptions do
+    assert_raises_when_not_swallowing_exceptions do
       @cache.increment("foo")
     end
   end
 
   def test_decrement_does_raise_on_error
-    raises_when_not_swallowing_exceptions do
+    assert_raises_when_not_swallowing_exceptions do
       @cache.decrement("foo")
     end
   end
 
   def test_reset_does_raise_on_error
-    raises_when_not_swallowing_exceptions do
+    assert_raises_when_not_swallowing_exceptions do
       @cache.reset
     end
   end
@@ -682,7 +682,7 @@ class TestMemcachedStore < ActiveSupport::TestCase
     client.read_only = previous
   end
 
-  def raises_when_not_swallowing_exceptions
+  def assert_raises_when_not_swallowing_exceptions
     expect_error
     @cache.swallow_exceptions = false
     assert_raise Memcached::Error do


### PR DESCRIPTION
This is a proposal on letting the callsite decide on whether exceptions raised should be silenced or should bubble up. The aim is being able to use `MemcachedStore` as a proper _store_, i.e. one that doesn't hide failures from the callsite. 
This is only step 1: I miss tests (I need to feed an actual `::Memcached` instance in there (as `Memcached::Rails` also swallows `Memcached::Error` instances. 
Then there needs to be an agreement on how to deal with `Memcached::NotFound` (i.e. misses): either leave it to the call site, or include this in `MemcachedStore` and simply return `nil` on misses.

This is more of a heads up and ground for discussion 