### PR TITLE
No more Memcached::Rails dep

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,5 @@
 inherit_from:
   - http://shopify.github.io/ruby-style-guide/rubocop.yml
+
+AllCops:
+  TargetRubyVersion: 2.2

--- a/test/test_memcached_snappy_store.rb
+++ b/test/test_memcached_snappy_store.rb
@@ -36,7 +36,7 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
 
       serialized_entry = Marshal.dump(entry)
       serialized_compressed_entry = Snappy.deflate(serialized_entry)
-      actual_cache_value = @cache.instance_variable_get(:@data).get(key, true)
+      actual_cache_value = @cache.instance_variable_get(:@data).get(key, false)
 
       assert_equal serialized_compressed_entry, actual_cache_value
     end
@@ -94,7 +94,7 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
     key = 'key'
     @cache.write(key, 'value', raw: true)
 
-    actual_cache_value = @cache.instance_variable_get(:@data).get(key, true)
+    actual_cache_value = @cache.instance_variable_get(:@data).get(key, false)
     assert_equal 'value', Snappy.inflate(actual_cache_value)
   end
 
@@ -111,7 +111,7 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
     assert result
     assert_equal update_value, @cache.read(key)
 
-    actual_cache_value = @cache.instance_variable_get(:@data).get(key, true)
+    actual_cache_value = @cache.instance_variable_get(:@data).get(key, false)
     serialized_entry = Snappy.inflate(actual_cache_value)
     entry = Marshal.load(serialized_entry)
     assert entry.is_a?(ActiveSupport::Cache::Entry)
@@ -126,7 +126,7 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
       'new_value'
     end
     assert result
-    actual_cache_value = @cache.instance_variable_get(:@data).get(key, true)
+    actual_cache_value = @cache.instance_variable_get(:@data).get(key, false)
     assert_equal 'new_value', Snappy.inflate(actual_cache_value)
   end
 
@@ -145,7 +145,7 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
     assert_equal Hash[keys.zip(values)].merge(update_hash), @cache.read_multi(*keys)
 
     update_hash.each do |key, value|
-      actual_cache_value = @cache.instance_variable_get(:@data).get(key, true)
+      actual_cache_value = @cache.instance_variable_get(:@data).get(key, false)
       serialized_entry = Snappy.inflate(actual_cache_value)
       entry = Marshal.load(serialized_entry)
       assert entry.is_a?(ActiveSupport::Cache::Entry)
@@ -165,7 +165,7 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
       update_hash
     end
     assert result
-    actual_cache_value = @cache.instance_variable_get(:@data).get("two", true)
+    actual_cache_value = @cache.instance_variable_get(:@data).get("two", false)
     assert_equal update_hash["two"], Snappy.inflate(actual_cache_value)
   end
 end

--- a/test/test_memcached_store.rb
+++ b/test/test_memcached_store.rb
@@ -84,7 +84,7 @@ class TestMemcachedStore < ActiveSupport::TestCase
   def test_cas_multi
     @cache.write('foo', 'bar')
     @cache.write('fud', 'biz')
-    assert(@cache.cas_multi('foo', 'fud') do |hash|
+    assert_equal true, (@cache.cas_multi('foo', 'fud') do |hash|
       assert_equal({ "foo" => "bar", "fud" => "biz" }, hash)
       { "foo" => "baz", "fud" => "buz" }
     end)
@@ -379,20 +379,22 @@ class TestMemcachedStore < ActiveSupport::TestCase
   def test_initialize_accepts_a_list_of_servers_in_options
     options = { servers: ["localhost:21211"] }
     cache = ActiveSupport::Cache.lookup_store(:memcached_store, options)
-    assert_equal 21211, cache.instance_variable_get(:@data).servers.first.port
+    servers = cache.instance_variable_get(:@data).servers
+    assert_equal ["localhost:21211"], extract_host_port_pairs(servers)
   end
 
   def test_multiple_servers
     options = { servers: ["localhost:21211", "localhost:11211"] }
     cache = ActiveSupport::Cache.lookup_store(:memcached_store, options)
-    assert_equal [21211, 11211], cache.instance_variable_get(:@data).servers.map(&:port)
+    servers = extract_host_port_pairs(cache.instance_variable_get(:@data).servers)
+    assert_equal ["localhost:21211", "localhost:11211"], servers
   end
 
   def test_namespace_without_servers
     options = { namespace: 'foo:' }
     cache = ActiveSupport::Cache.lookup_store(:memcached_store, options)
     client = cache.instance_variable_get(:@data)
-    assert_equal [11211], client.servers.map(&:port)
+    assert_equal ["127.0.0.1:11211:8"], client.servers
     assert_equal "", client.prefix_key, "should not send the namespace to the client"
     assert_equal "foo::key", cache.send(:namespaced_key, "key", cache.options)
   end
@@ -613,6 +615,10 @@ class TestMemcachedStore < ActiveSupport::TestCase
     yield
   ensure
     client.read_only = previous
+  end
+
+  def extract_host_port_pairs(servers)
+    servers.map { |host| host.split(':')[0..1].join(':') }
   end
 
   def expect_not_found


### PR DESCRIPTION
This replaces `Memcached::Rails` as the backend for `MemcachedStore` with a plain `Memcached` instance.

 - `FATAL_EXCEPTIONS` never bubbled up, as `Memcached::Rails` catches all `Memcached::Error` anyways, the behavior of `MemcachedStore` is kept the same and that path is hence deleted.

This is a first pass at cleaning this up. I'll then rebase PR #31 to use this and move forward. 