### PR TITLE
Ensure duration in the expiration method is converted to integer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ env:
   - "AS_VERSION=4.1.0"
   - "AS_VERSION=4.2.0"
   - "AS_VERSION=5.0.0"
+  - "AS_VERSION=5.1.0"
 notifications:
   email: false

--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -239,7 +239,7 @@ module ActiveSupport
         expires_in = options[:expires_in].to_i
         if expires_in > 0 && !options[:raw]
           # Set the memcache expire a few minutes in the future to support race condition ttls on read
-          expires_in += 5.minutes
+          expires_in += 5.minutes.to_i
         end
         expires_in
       end

--- a/test/test_memcached_store.rb
+++ b/test/test_memcached_store.rb
@@ -396,7 +396,7 @@ class TestMemcachedStore < ActiveSupport::TestCase
     client = cache.instance_variable_get(:@data)
     assert_equal ["127.0.0.1:11211"], extract_host_port_pairs(client.servers)
     assert_equal "", client.prefix_key, "should not send the namespace to the client"
-    assert_equal "foo::key", cache.send(:namespaced_key, "key", cache.options)
+    assert_equal "foo::key", cache.send(:normalize_key, "key", cache.options)
   end
 
   def test_reset


### PR DESCRIPTION
When using `memcached_store` in Rails 5.1 the private `expiration` method extends the original expiration by 5 minutes to prevent race condition on read. However the new returned expiration is an `ActiveSupport::Duration` which is not coerced into an integer and causing the underlying `memcached_set` call to fail with the exception:

```
TypeError: Expected argument 5 of type time_t, but got ActiveSupport::Duration 5 minutes and 60 seconds in SWIG method 'memcached_set'
.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/memcached-1.8.0/lib/memcached/memcached.rb:320:in `memcached_set'
```
Please note test will fail by running in the command line:
```sh
AS_VERSION='5.1.1' bundle
AS_VERSION='5.1.1' bundle exec rake test
```

In Rails 5.1 the method `namespaced_key` has been removed and we should use instead `normalize_key`. This PR also fixes that test.

Fixes https://github.com/Shopify/memcached_store/issues/36