### PR TITLE
Added `on_error` handler

### DIFF
--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -14,6 +14,7 @@ module ActiveSupport
       ESCAPE_KEY_CHARS = /[\x00-\x20%\x7F-\xFF]/n
 
       attr_accessor :read_only, :swallow_exceptions
+      attr_writer :on_error
 
       def initialize(*addresses)
         addresses = addresses.flatten
@@ -251,6 +252,7 @@ module ActiveSupport
       rescue Memcached::NotFound, Memcached::ConnectionDataExists
         on_miss
       rescue Memcached::Error => e
+        @on_error.call(e) if @on_error
         raise unless @swallow_exceptions
         logger.warn("memcached error: #{e.class}: #{e.message}") if logger
         return_value_on_error

--- a/test/test_memcached_store.rb
+++ b/test/test_memcached_store.rb
@@ -618,6 +618,17 @@ class TestMemcachedStore < ActiveSupport::TestCase
     end
   end
 
+  def test_error_calls_on_error_handler
+    error = Memcached::Error.new("error")
+    @cache.instance_variable_get(:@data).expects(:check_return_code).raises(error)
+
+    error_handler = proc {}
+    error_handler.expects(:call).with(error).once
+
+    @cache.on_error = error_handler
+    @cache.read("foo")
+  end
+
   def test_read_multi_does_raise_on_error
     assert_raises_when_not_swallowing_exceptions do
       @cache.read_multi(%w(foo bar))


### PR DESCRIPTION
Added `on_error` handler that is invoked on every error regardless of `swallow_exceptions` setting. This allows for custom handling of errors on per-cache basis without raising exceptions.