### PR TITLE
Test and support Rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
+sudo: false
+cache: bundler
 language: ruby
 services: memcache
 before_install:
   - gem update bundler
 rvm:
-  - 2.2.6
-  - 2.3.3
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0
 env:
   - "AS_VERSION=4.0.5"
   - "AS_VERSION=4.1.0"
   - "AS_VERSION=4.2.0"
   - "AS_VERSION=5.0.0"
   - "AS_VERSION=5.1.0"
+  - "AS_VERSION=5.2.0.rc1"
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in rails_cache_adapters.gemspec
 gemspec
 
-version = ENV["AS_VERSION"] || "5.0.0"
+version = ENV["AS_VERSION"] || "5.2.0.rc1"
 as_version = case version
 when "master"
   { github: "rails/rails" }

--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -209,7 +209,8 @@ module ActiveSupport
           key = super.dup
           key = key.force_encoding(Encoding::ASCII_8BIT)
           key = key.gsub(ESCAPE_KEY_CHARS) { |match| "%#{match.getbyte(0).to_s(16).upcase}" }
-          key = "#{key[0, 213]}:md5:#{Digest::MD5.hexdigest(key)}" if key.size > 250
+          # When we remove support to Rails 5.1 we can change the code to use ActiveSupport::Digest
+          key = "#{key[0, 213]}:md5:#{::Digest::MD5.hexdigest(key)}" if key.size > 250
           key
         end
 


### PR DESCRIPTION
Rails 5.2 define a ActiveSupport::Digest module and without the full name the autoload were looking for MD5 inside ActiveSupport::Digest instead of ::Digest.