### PR TITLE
do not extend :expires_in if :race_condition_ttl is not provided

### DIFF
--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -271,9 +271,8 @@ module ActiveSupport
 
       def expiration(options)
         expires_in = options[:expires_in].to_i
-        if expires_in > 0 && !options[:raw]
-          # Set the memcache expire a few minutes in the future to support race condition ttls on read
-          expires_in += 5.minutes.to_i
+        if expires_in > 0 && options[:race_condition_ttl] && !options[:raw]
+          expires_in += options[:race_condition_ttl].to_i
         end
         expires_in
       end

--- a/test/test_memcached_snappy_store.rb
+++ b/test/test_memcached_snappy_store.rb
@@ -62,7 +62,11 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
 
   test "get should work when there is a connection fail" do
     key = 'ponies2'
-    @cache.instance_variable_get(:@connection).expects(:check_return_code).raises(Memcached::ConnectionFailure).at_least_once
+    @cache.instance_variable_get(:@connection)
+      .expects(:check_return_code)
+      .raises(Memcached::ConnectionFailure)
+      .at_least_once
+
     assert_nil @cache.read(key)
   end
 

--- a/test/test_memcached_snappy_store.rb
+++ b/test/test_memcached_snappy_store.rb
@@ -36,7 +36,7 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
 
       serialized_entry = Marshal.dump(entry)
       serialized_compressed_entry = Snappy.deflate(serialized_entry)
-      actual_cache_value = @cache.instance_variable_get(:@data).get(key, false)
+      actual_cache_value = @cache.instance_variable_get(:@connection).get(key, false)
 
       assert_equal serialized_compressed_entry, actual_cache_value
     end
@@ -62,7 +62,7 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
 
   test "get should work when there is a connection fail" do
     key = 'ponies2'
-    @cache.instance_variable_get(:@data).expects(:check_return_code).raises(Memcached::ConnectionFailure).at_least_once
+    @cache.instance_variable_get(:@connection).expects(:check_return_code).raises(Memcached::ConnectionFailure).at_least_once
     assert_nil @cache.read(key)
   end
 
@@ -94,7 +94,7 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
     key = 'key'
     @cache.write(key, 'value', raw: true)
 
-    actual_cache_value = @cache.instance_variable_get(:@data).get(key, false)
+    actual_cache_value = @cache.instance_variable_get(:@connection).get(key, false)
     assert_equal 'value', Snappy.inflate(actual_cache_value)
   end
 
@@ -111,7 +111,7 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
     assert result
     assert_equal update_value, @cache.read(key)
 
-    actual_cache_value = @cache.instance_variable_get(:@data).get(key, false)
+    actual_cache_value = @cache.instance_variable_get(:@connection).get(key, false)
     serialized_entry = Snappy.inflate(actual_cache_value)
     entry = Marshal.load(serialized_entry)
     assert entry.is_a?(ActiveSupport::Cache::Entry)
@@ -126,7 +126,7 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
       'new_value'
     end
     assert result
-    actual_cache_value = @cache.instance_variable_get(:@data).get(key, false)
+    actual_cache_value = @cache.instance_variable_get(:@connection).get(key, false)
     assert_equal 'new_value', Snappy.inflate(actual_cache_value)
   end
 
@@ -145,7 +145,7 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
     assert_equal Hash[keys.zip(values)].merge(update_hash), @cache.read_multi(*keys)
 
     update_hash.each do |key, value|
-      actual_cache_value = @cache.instance_variable_get(:@data).get(key, false)
+      actual_cache_value = @cache.instance_variable_get(:@connection).get(key, false)
       serialized_entry = Snappy.inflate(actual_cache_value)
       entry = Marshal.load(serialized_entry)
       assert entry.is_a?(ActiveSupport::Cache::Entry)
@@ -165,7 +165,7 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
       update_hash
     end
     assert result
-    actual_cache_value = @cache.instance_variable_get(:@data).get("two", false)
+    actual_cache_value = @cache.instance_variable_get(:@connection).get("two", false)
     assert_equal update_hash["two"], Snappy.inflate(actual_cache_value)
   end
 end

--- a/test/test_memcached_store.rb
+++ b/test/test_memcached_store.rb
@@ -13,7 +13,7 @@ class TestMemcachedStore < ActiveSupport::TestCase
   def test_accepts_memcached_instance_as_server
     memcached = Memcached.new
     store = ActiveSupport::Cache::MemcachedStore.new(memcached)
-    assert memcached.equal?(store.instance_variable_get(:@data))
+    assert memcached.equal?(store.instance_variable_get(:@connection))
   end
 
   def test_does_not_accepts_memcached_rails_instance_as_server
@@ -392,28 +392,28 @@ class TestMemcachedStore < ActiveSupport::TestCase
   def test_initialize_accepts_a_list_of_servers_in_options
     options = { servers: ["localhost:21211"] }
     cache = ActiveSupport::Cache.lookup_store(:memcached_store, options)
-    servers = cache.instance_variable_get(:@data).servers
+    servers = cache.instance_variable_get(:@connection).servers
     assert_equal ["localhost:21211"], extract_host_port_pairs(servers)
   end
 
   def test_multiple_servers
     options = { servers: ["localhost:21211", "localhost:11211"] }
     cache = ActiveSupport::Cache.lookup_store(:memcached_store, options)
-    servers = extract_host_port_pairs(cache.instance_variable_get(:@data).servers)
+    servers = extract_host_port_pairs(cache.instance_variable_get(:@connection).servers)
     assert_equal ["localhost:21211", "localhost:11211"], servers
   end
 
   def test_namespace_without_servers
     options = { namespace: 'foo:' }
     cache = ActiveSupport::Cache.lookup_store(:memcached_store, options)
-    client = cache.instance_variable_get(:@data)
+    client = cache.instance_variable_get(:@connection)
     assert_equal ["127.0.0.1:11211"], extract_host_port_pairs(client.servers)
     assert_equal "", client.prefix_key, "should not send the namespace to the client"
     assert_equal "foo::key", cache.send(:normalize_key, "key", cache.options)
   end
 
   def test_reset
-    client = @cache.instance_variable_get(:@data)
+    client = @cache.instance_variable_get(:@connection)
     client.expects(:reset).once
     @cache.reset
   end
@@ -510,7 +510,7 @@ class TestMemcachedStore < ActiveSupport::TestCase
 
         assert_equal "no", value
         refute @cache.fetch("walrus"), "Client should return nil for expired key"
-        assert_equal "yo", @cache.instance_variable_get(:@data).get("walrus").value
+        assert_equal "yo", @cache.instance_variable_get(:@connection).get("walrus").value
       end
     end
   end
@@ -528,7 +528,7 @@ class TestMemcachedStore < ActiveSupport::TestCase
         assert_equal "no", @cache.fetch("walrus") { "no" }
         refute @cache.fetch("walrus")
 
-        assert_equal "yo", @cache.instance_variable_get(:@data).get("walrus").value
+        assert_equal "yo", @cache.instance_variable_get(:@connection).get("walrus").value
       end
     end
   end
@@ -541,7 +541,7 @@ class TestMemcachedStore < ActiveSupport::TestCase
       with_read_only(@cache) do
         refute @cache.read("walrus")
 
-        assert_equal "yo", @cache.instance_variable_get(:@data).get("walrus").value
+        assert_equal "yo", @cache.instance_variable_get(:@connection).get("walrus").value
       end
     end
   end
@@ -555,8 +555,8 @@ class TestMemcachedStore < ActiveSupport::TestCase
       with_read_only(@cache) do
         assert_predicate @cache.read_multi("walrus", "narwhal"), :empty?
 
-        assert_equal "yo", @cache.instance_variable_get(:@data).get("walrus").value
-        assert_equal "yiir", @cache.instance_variable_get(:@data).get("narwhal").value
+        assert_equal "yo", @cache.instance_variable_get(:@connection).get("walrus").value
+        assert_equal "yiir", @cache.instance_variable_get(:@connection).get("narwhal").value
       end
     end
   end
@@ -803,18 +803,18 @@ class TestMemcachedStore < ActiveSupport::TestCase
   end
 
   def expect_not_found
-    @cache.instance_variable_get(:@data).expects(:check_return_code).raises(Memcached::NotFound)
+    @cache.instance_variable_get(:@connection).expects(:check_return_code).raises(Memcached::NotFound)
   end
 
   def expect_not_stored
-    @cache.instance_variable_get(:@data).expects(:check_return_code).raises(Memcached::NotStored)
+    @cache.instance_variable_get(:@connection).expects(:check_return_code).raises(Memcached::NotStored)
   end
 
   def expect_data_exists
-    @cache.instance_variable_get(:@data).expects(:check_return_code).raises(Memcached::ConnectionDataExists)
+    @cache.instance_variable_get(:@connection).expects(:check_return_code).raises(Memcached::ConnectionDataExists)
   end
 
   def expect_error
-    @cache.instance_variable_get(:@data).expects(:check_return_code).raises(Memcached::Error)
+    @cache.instance_variable_get(:@connection).expects(:check_return_code).raises(Memcached::Error)
   end
 end


### PR DESCRIPTION
Activesupport has a universal option, `:race_condition_ttl`, that's meant to reduce thundering herd effect on very high traffic code paths:

```
      # Setting <tt>:race_condition_ttl</tt> is very useful in situations where
      # a cache entry is used very frequently and is under heavy load. If a
      # cache expires and due to heavy load several different processes will try
      # to read data natively and then they all will try to write to cache. To
      # avoid that case the first process to find an expired cache entry will
      # bump the cache expiration time by the value set in <tt>:race_condition_ttl</tt>.
      # Yes, this process is extending the time for a stale value by another few
      # seconds. Because of extended life of the previous cache, other processes
      # will continue to use slightly stale data for a just a bit longer. In the
      # meantime that first process will go ahead and will write into cache the
      # new value. After that all the processes will start getting the new value.
      # The key is to keep <tt>:race_condition_ttl</tt> small.
```

However, this option is awkward to support on a remote caching server like memcached. Other memcached libraries like Dalli have gone as far as [removing support](https://github.com/petergoldstein/dalli/blob/master/History.md#200) for it.

The reason is that in order to support this option, we have to extend the user-provided TTL by some amount of time so that the entry is accessible to activesupport even though it has already expired ([so that activesupport can perform its logic for the `:race_condition_ttl` option](https://github.com/rails/rails/blob/6aa5cf03ea8232180ffbbae4c130b051f813c670/activesupport/lib/active_support/cache.rb#L673-L681)). Even worse, the expiration deadline is set and checked using worker machine times if activesupport is handling the TTL deadline (as opposed to the key disappearing from the memcached server).

We cannot remove support for the `:race_condition_ttl` option right away but we can support this in a nicer way. After this PR:

* Only extend TTL if the `race_condition_ttl` option is provided. Majority of keys are then expired by the server rather than unreliable delete calls.
* Extend the TTL only by `:race_condition_ttl` duration. I don't see a good reason to use 5 minutes. If the code path is high traffic then this should be sufficient. If it is not, then using the option doesn't make sense and the key can safely expire.

cc @Shopify/pods related to https://github.com/Shopify/shopify/pull/153748