### PR TITLE
Log errors all the time with more metadata instead

### DIFF
--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -14,7 +14,6 @@ module ActiveSupport
       ESCAPE_KEY_CHARS = /[\x00-\x20%\x7F-\xFF]/n
 
       attr_accessor :read_only, :swallow_exceptions
-      attr_writer :on_error
 
       def initialize(*addresses)
         addresses = addresses.flatten
@@ -248,9 +247,10 @@ module ActiveSupport
       rescue Memcached::NotFound, Memcached::ConnectionDataExists
         on_miss
       rescue Memcached::Error => e
-        @on_error.call(e) if @on_error
+        logger.warn(
+          "[MEMCACHED_ERROR] swallowed=#{@swallow_exceptions} exception_class=#{e.class} exception_message=#{e.message}"
+        ) if logger
         raise unless @swallow_exceptions
-        logger.warn("memcached error: #{e.class}: #{e.message}") if logger
         return_value_on_error
       end
 


### PR DESCRIPTION
Instead of [dealing with a callback proc that logs all the time](https://github.com/Shopify/shopify/blob/master/lib/active_support/cache/proxy_cache_store.rb#L70-L74) (and introduce confusing duplicated logs), I'm simply switching it to always log and append additional metadata to the log entry. This way it's easier to understand why this happens.

