### PR TITLE
bump to 2.0.0

### DIFF
--- a/lib/memcached_store/version.rb
+++ b/lib/memcached_store/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module MemcachedStore
-  VERSION = "1.2.2"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
Includes https://github.com/Shopify/memcached_store/compare/0638656...master. Since it's a breaking change, I'm bumping the major version.