### PR TITLE
Bump 2.0.1

### DIFF
--- a/lib/memcached_store/version.rb
+++ b/lib/memcached_store/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module MemcachedStore
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end


### PR DESCRIPTION
Includes https://github.com/Shopify/memcached_store/compare/5d9d806d269b20f08094c26899f7674822bde458...master. No breaking changes, so I think bumping the minor is 🆗 .