### PR TITLE
Use memcached flags to detect need for unmarshalling and decompressing

### DIFF
--- a/lib/active_support/cache/memcached_snappy_store.rb
+++ b/lib/active_support/cache/memcached_snappy_store.rb
@@ -12,6 +12,16 @@ module ActiveSupport
     class MemcachedSnappyStore < MemcachedStore
       class UnsupportedOperation < StandardError; end
 
+      module SnappyCompressor
+        def self.compress(source)
+          Snappy.deflate(source)
+        end
+
+        def self.decompress(source)
+          Snappy.inflate(source)
+        end
+      end
+
       def increment(*)
         raise UnsupportedOperation, "increment is not supported by: #{self.class.name}"
       end
@@ -25,21 +35,9 @@ module ActiveSupport
         false
       end
 
-      private
-
-      def serialize_entry(entry, options)
-        value = options[:raw] ? entry.value.to_s : Marshal.dump(entry)
-        [Snappy.deflate(value), true]
-      end
-
-      def deserialize_entry(compressed_value)
-        if compressed_value
-          super(Snappy.inflate(compressed_value))
-        end
-      end
-
-      def cas_raw?(_options)
-        true
+      def initialize(*addresses, **options)
+        options[:codec] ||= ActiveSupport::Cache::MemcachedStore::Codec.new(compressor: SnappyCompressor)
+        super(*addresses, **options)
       end
     end
   end

--- a/lib/active_support/cache/memcached_snappy_store.rb
+++ b/lib/active_support/cache/memcached_snappy_store.rb
@@ -37,6 +37,7 @@ module ActiveSupport
 
       def initialize(*addresses, **options)
         options[:codec] ||= ActiveSupport::Cache::MemcachedStore::Codec.new(compressor: SnappyCompressor)
+        options[:compress] = false
         super(*addresses, **options)
       end
     end

--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -30,7 +30,7 @@ module ActiveSupport
           @compressor = compressor
         end
 
-        def encode(key, value, flags)
+        def encode(_key, value, flags)
           flags &= CLEAR_USED_FLAGS_MASK
           unless value.is_a?(String)
             flags |= SERIALIZED_FLAG
@@ -44,7 +44,7 @@ module ActiveSupport
           [value, flags]
         end
 
-        def decode(key, value, flags)
+        def decode(_key, value, flags)
           if (flags & COMPRESSED_FLAG) != 0
             value = @compressor.decompress(value)
           end

--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -13,11 +13,57 @@ module ActiveSupport
     class MemcachedStore < Store
       ESCAPE_KEY_CHARS = /[\x00-\x20%\x7F-\xFF]/n
 
+      class Codec
+        # use dalli compatible flags
+        SERIALIZED_FLAG = 0x1
+        COMPRESSED_FLAG = 0x2
+
+        # Older versions of this gem would use 0 for the flags whether or not
+        # the value was marshal dumped. By setting this flag, we can tell if
+        # it were set with an older version for backwards compatible decoding.
+        RAW_FLAG = 0x10
+
+        CLEAR_USED_FLAGS_MASK = ~(SERIALIZED_FLAG | COMPRESSED_FLAG | RAW_FLAG)
+
+        def initialize(serializer: Marshal, compressor: nil)
+          @serializer = serializer
+          @compressor = compressor
+        end
+
+        def encode(key, value, flags)
+          flags &= CLEAR_USED_FLAGS_MASK
+          unless value.is_a?(String)
+            flags |= SERIALIZED_FLAG
+            value = @serializer.dump(value)
+          end
+          if @compressor
+            flags |= COMPRESSED_FLAG
+            value = @compressor.compress(value)
+          end
+          flags |= RAW_FLAG if flags == 0
+          [value, flags]
+        end
+
+        def decode(key, value, flags)
+          if (flags & COMPRESSED_FLAG) != 0
+            value = @compressor.decompress(value)
+          end
+
+          if (flags & SERIALIZED_FLAG) != 0
+            @serializer.load(value)
+          elsif flags == 0 # legacy cache value
+            @serializer.load(value) rescue value
+          else
+            value
+          end
+        end
+      end
+
       attr_accessor :read_only, :swallow_exceptions
 
-      def initialize(*addresses)
+      def initialize(*addresses, **options)
         addresses = addresses.flatten
-        options = addresses.extract_options!
+        options[:codec] ||= Codec.new
         @swallow_exceptions = true
         @swallow_exceptions = options.delete(:swallow_exceptions) if options.key?(:swallow_exceptions)
 
@@ -57,7 +103,7 @@ module ActiveSupport
 
         handle_exceptions(return_value_on_error: {}) do
           instrument(:read_multi, names, options) do
-            if raw_values = @data.get(keys_to_names.keys, false)
+            if raw_values = @data.get(keys_to_names.keys)
               raw_values.each do |key, value|
                 entry = deserialize_entry(value)
                 values[keys_to_names[key]] = entry.value unless entry.expired?
@@ -74,19 +120,18 @@ module ActiveSupport
 
         handle_exceptions(return_value_on_error: false) do
           instrument(:cas, name, options) do
-            @data.cas(key, expiration(options), !cas_raw?(options)) do |raw_value|
+            @data.cas(key, expiration(options)) do |raw_value|
               entry = deserialize_entry(raw_value)
               value = yield entry.value
               break true if read_only
-              serialize_entry(Entry.new(value, options), options).first
+              serialize_entry(Entry.new(value, options), options)
             end
           end
           true
         end
       end
 
-      def cas_multi(*names)
-        options = names.extract_options!
+      def cas_multi(*names, **options)
         return if names.empty?
 
         options = merged_options(options)
@@ -94,7 +139,7 @@ module ActiveSupport
 
         handle_exceptions(return_value_on_error: false) do
           instrument(:cas_multi, names, options) do
-            @data.cas(keys_to_names.keys, expiration(options), !cas_raw?(options)) do |raw_values|
+            @data.cas(keys_to_names.keys, expiration(options)) do |raw_values|
               values = {}
 
               raw_values.each do |key, raw_value|
@@ -107,7 +152,7 @@ module ActiveSupport
               break true if read_only
 
               serialized_values = values.map do |name, value|
-                [normalize_key(name, options), serialize_entry(Entry.new(value, options), options).first]
+                [normalize_key(name, options), serialize_entry(Entry.new(value, options), options)]
               end
 
               Hash[serialized_values]
@@ -161,7 +206,7 @@ module ActiveSupport
 
       def read_entry(key, _options) # :nodoc:
         handle_exceptions(return_value_on_error: nil) do
-          deserialize_entry(@data.get(escape_key(key), false))
+          deserialize_entry(@data.get(escape_key(key)))
         end
       end
 
@@ -169,9 +214,9 @@ module ActiveSupport
         return true if read_only
         method = options && options[:unless_exist] ? :add : :set
         expires_in = expiration(options)
-        value, raw = serialize_entry(entry, options)
+        value = serialize_entry(entry, options)
         handle_exceptions(return_value_on_error: false) do
-          @data.send(method, escape_key(key), value, expires_in, !raw)
+          @data.send(method, escape_key(key), value, expires_in)
           true
         end
       end
@@ -213,24 +258,18 @@ module ActiveSupport
         end
       end
 
-      def deserialize_entry(raw_value)
-        if raw_value
-          entry = begin
-                      Marshal.load(raw_value)
-                    rescue
-                      raw_value
-                    end
-          entry.is_a?(Entry) ? entry : Entry.new(entry)
+      def deserialize_entry(value)
+        if value
+          value.is_a?(Entry) ? value : Entry.new(value)
         end
       end
 
       def serialize_entry(entry, options)
-        entry = entry.value.to_s if options[:raw]
-        [entry, options[:raw]]
-      end
-
-      def cas_raw?(options)
-        options[:raw]
+        if options[:raw]
+          entry.value.to_s
+        else
+          entry
+        end
       end
 
       def expiration(options)

--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -23,15 +23,12 @@ module ActiveSupport
         # it were set with an older version for backwards compatible decoding.
         RAW_FLAG = 0x10
 
-        CLEAR_USED_FLAGS_MASK = ~(SERIALIZED_FLAG | COMPRESSED_FLAG | RAW_FLAG)
-
         def initialize(serializer: Marshal, compressor: nil)
           @serializer = serializer
           @compressor = compressor
         end
 
         def encode(_key, value, flags)
-          flags &= CLEAR_USED_FLAGS_MASK
           unless value.is_a?(String)
             flags |= SERIALIZED_FLAG
             value = @serializer.dump(value)

--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -260,7 +260,7 @@ module ActiveSupport
 
       def deserialize_entry(value)
         if value
-          value.is_a?(Entry) ? value : Entry.new(value)
+          value.is_a?(Entry) ? value : Entry.new(value, compresss: false)
         end
       end
 

--- a/test/test_memcached_snappy_store.rb
+++ b/test/test_memcached_snappy_store.rb
@@ -69,7 +69,7 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
   test "should use snappy to multi read cache entries but not on missing entries" do
     keys = %w(one tow three)
     values = keys.map { |k| k * 10 }
-    entries = values.map { |v| ActiveSupport::Cache::Entry.new(v) }
+    entries = values.map { |v| Marshal.dump(ActiveSupport::Cache::Entry.new(v)) }
 
     keys.each_with_index { |k, i| @cache.write(k, values[i]) }
 
@@ -82,7 +82,7 @@ class TestMemcachedSnappyStore < ActiveSupport::TestCase
   test "should use snappy to multi read cache entries" do
     keys = %w(one tow three)
     values = keys.map { |k| k * 10 }
-    entries = values.map { |v| ActiveSupport::Cache::Entry.new(v) }
+    entries = values.map { |v| Marshal.dump(ActiveSupport::Cache::Entry.new(v)) }
 
     keys.each_with_index { |k, i| @cache.write(k, values[i]) }
 

--- a/test/test_memcached_store.rb
+++ b/test/test_memcached_store.rb
@@ -744,6 +744,20 @@ class TestMemcachedStore < ActiveSupport::TestCase
     end
   end
 
+  def test_decoding_keys_written_using_old_version
+    memcached = Memcached.new
+    memcached.set("serialized", Marshal.dump(:old), 60, false)
+    assert_equal :old, @cache.read('serialized')
+    memcached.set("raw", "old", 60, false)
+    assert_equal "old", @cache.read('raw')
+  end
+
+  def test_raw_option_not_needed_on_read
+    raw_data = Marshal.dump(:raw)
+    @cache.write("raw", raw_data, raw: true)
+    assert_equal raw_data, @cache.read('raw')
+  end
+
   private
 
   def assert_notifications(pattern, num)


### PR DESCRIPTION
## Problem

I would like a cleaner and more flexible ActiveSupport::Cache::MemcachedStore so we don't need to inherit from and patch its methods to change the serializer or add compression.  I think we should also support conditional compression based a minimum and maximum size, which requires marking the key as being compressed to detect whether it needs to be decompressed.

## Solution

memcached supports having flags associated with keys, which are typically used to indicate the format of the cache value.  The memcached gem allows these to be leveraged by providing a codec.  Dalli also uses these flags for serialization and conditional compression, so I've used the same serialized and compressed flags.

This PR doesn't add conditional compression, but that can be done in a follow-up PR.