### PR TITLE
Fix typo and never compress when reading an Entry's value

### DIFF
--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -257,7 +257,7 @@ module ActiveSupport
 
       def deserialize_entry(value)
         if value
-          value.is_a?(Entry) ? value : Entry.new(value, compresss: false)
+          value.is_a?(Entry) ? value : Entry.new(value, compress: false)
         end
       end
 

--- a/lib/memcached_store/version.rb
+++ b/lib/memcached_store/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module MemcachedStore
-  VERSION = "2.0.2"
+  VERSION = "2.0.3"
 end

--- a/test/test_memcached_store.rb
+++ b/test/test_memcached_store.rb
@@ -758,6 +758,16 @@ class TestMemcachedStore < ActiveSupport::TestCase
     assert_equal raw_data, @cache.read('raw')
   end
 
+  def test_uncompress_regression
+    Zlib::Inflate.expects(:inflate).never
+    Zlib::Deflate.expects(:deflate).never
+
+    value = "bar" * ActiveSupport::Cache::Entry::DEFAULT_COMPRESS_LIMIT
+
+    @cache.write("foo", value, raw: true)
+    assert_equal(value, @cache.read("foo"))
+  end
+
   private
 
   def assert_notifications(pattern, num)

--- a/test/test_memcached_store.rb
+++ b/test/test_memcached_store.rb
@@ -759,11 +759,11 @@ class TestMemcachedStore < ActiveSupport::TestCase
   end
 
   def test_uncompress_regression
-    Zlib::Deflate.expects(:deflate).never
-
     value = "bar" * ActiveSupport::Cache::Entry::DEFAULT_COMPRESS_LIMIT
+    Zlib::Deflate.expects(:deflate).never
+    Zlib::Inflate.expects(:inflate).never
 
-    @cache.write("foo", value, raw: true)
+    @cache.write("foo", value, raw: true, compress: false)
     assert_equal(value, @cache.read("foo"))
   end
 

--- a/test/test_memcached_store.rb
+++ b/test/test_memcached_store.rb
@@ -759,7 +759,6 @@ class TestMemcachedStore < ActiveSupport::TestCase
   end
 
   def test_uncompress_regression
-    Zlib::Inflate.expects(:inflate).never
     Zlib::Deflate.expects(:deflate).never
 
     value = "bar" * ActiveSupport::Cache::Entry::DEFAULT_COMPRESS_LIMIT


### PR DESCRIPTION
This was actually trying to compress values that shouldn't actually be compressed. I've added a regression test to make sure we only compress it once.