### PR TITLE
Test against Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,20 @@ sudo: false
 cache: bundler
 language: ruby
 services: memcache
-before_install:
-  - gem update bundler
+
 rvm:
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - "2.5"
+  - "2.6"
+  - "2.7"
+
 env:
-  - "AS_VERSION=4.0.5"
-  - "AS_VERSION=4.1.0"
-  - "AS_VERSION=4.2.0"
-  - "AS_VERSION=5.0.0"
-  - "AS_VERSION=5.1.0"
-  - "AS_VERSION=5.2.0.rc1"
+  - "AS_VERSION=5.2.0"
+  - "AS_VERSION=6.0.0"
+
+jobs:
+  exclude:
+    - rvm: "2.7"
+      env: "AS_VERSION=5.2.0"
+
 notifications:
   email: false

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ Rake::TestTask.new do |t|
   t.libs << "test"
   t.libs << "lib/**/*"
   t.test_files = FileList['test/test*.rb']
-  t.verbose = true
+  t.verbose = false # memcached gem has loads of uninitialized instance variables
 end
 
 task tag: :build do

--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -134,7 +134,7 @@ module ActiveSupport
               entry = deserialize_entry(raw_value)
               value = yield entry.value
               break true if read_only
-              serialize_entry(Entry.new(value, options), options)
+              serialize_entry(Entry.new(value, **options), options)
             end
           end
           true
@@ -162,7 +162,7 @@ module ActiveSupport
               break true if read_only
 
               serialized_values = values.map do |name, value|
-                [normalize_key(name, options), serialize_entry(Entry.new(value, options), options)]
+                [normalize_key(name, options), serialize_entry(Entry.new(value, **options), options)]
               end
 
               Hash[serialized_values]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 require 'minitest/autorun'
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'timecop'
 
 require 'active_support'

--- a/test/test_memcached_store.rb
+++ b/test/test_memcached_store.rb
@@ -30,7 +30,7 @@ class TestMemcachedStore < ActiveSupport::TestCase
 
   def test_fetch_not_found
     expect_not_found
-    assert_equal nil, @cache.fetch('not_exist')
+    assert_nil @cache.fetch('not_exist')
   end
 
   def test_should_read_and_write_strings
@@ -162,7 +162,7 @@ class TestMemcachedStore < ActiveSupport::TestCase
 
   def test_should_read_and_write_nil
     assert @cache.write('foo', nil)
-    assert_equal nil, @cache.read('foo')
+    assert_nil @cache.read('foo')
   end
 
   def test_should_read_and_write_false
@@ -299,7 +299,7 @@ class TestMemcachedStore < ActiveSupport::TestCase
     @cache.write('foo', 'bar', expires_in: 60)
     Time.stubs(:now).returns(time + 71)
     result = @cache.fetch('foo', race_condition_ttl: 10) do
-      assert_equal nil, @cache.read('foo')
+      assert_nil @cache.read('foo')
       "baz"
     end
     assert_equal "baz", result
@@ -354,7 +354,7 @@ class TestMemcachedStore < ActiveSupport::TestCase
 
   def test_increment_not_found
     expect_not_found
-    assert_equal nil, @cache.increment('not_exist')
+    assert_nil @cache.increment('not_exist')
   end
 
   def test_decrement
@@ -369,7 +369,7 @@ class TestMemcachedStore < ActiveSupport::TestCase
 
   def test_decrement_not_found
     expect_not_found
-    assert_equal nil, @cache.decrement('not_exist')
+    assert_nil @cache.decrement('not_exist')
   end
 
   def test_common_utf8_values


### PR DESCRIPTION
Fairly straightforwards. 

```
/tmp/bundle/ruby/2.7.0/gems/memcached_store-2.1.4/lib/active_support/cache/memcached_store.rb:137: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/tmp/bundle/ruby/2.7.0/bundler/gems/rails-cdbce035a5b0/activesupport/lib/active_support/cache.rb:763: warning: The called method `initialize' is defined here
/tmp/bundle/ruby/2.7.0/gems/memcached_store-2.1.4/lib/active_support/cache/memcached_store.rb:165: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/tmp/bundle/ruby/2.7.0/bundler/gems/rails-cdbce035a5b0/activesupport/lib/active_support/cache.rb:763: warning: The called method `initialize' is defined here
```