### PR TITLE
Prepend Strategy::LocalCache

### DIFF
--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -58,6 +58,8 @@ module ActiveSupport
 
       attr_accessor :read_only, :swallow_exceptions
 
+      prepend(Strategy::LocalCache)
+
       def initialize(*addresses, **options)
         addresses = addresses.flatten
         options[:codec] ||= Codec.new
@@ -76,8 +78,6 @@ module ActiveSupport
           UNIVERSAL_OPTIONS.each { |name| mem_cache_options.delete(name) }
           @connection = Memcached.new([*addresses, *servers], mem_cache_options)
         end
-
-        extend Strategy::LocalCache
       end
 
       def append(name, value, options = nil)


### PR DESCRIPTION
Use `prepend` instead of `extend` in the initializer to mix in the LocalCache strategy. This allows other modules to override methods in the class.
