### PR TITLE
Change deserialize_entry check for value to be able to cache a boolean atribute

### DIFF
--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -269,7 +269,7 @@ module ActiveSupport
       end
 
       def deserialize_entry(value)
-        if value
+        unless value.nil?
           value.is_a?(Entry) ? value : Entry.new(value, compress: false)
         end
       end


### PR DESCRIPTION
When using cache_attribute of  https://github.com/Shopify/identity_cache to cache a boolean columns, fetching false from cache fails.

This PR aims to fix that.