### PR TITLE
Fix rails edge tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,6 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.entry.ruby }}
+        rubygems: '3.3.13'
         bundler-cache: true
     - run: bundle exec rake


### PR DESCRIPTION
Tests on rails edge are failing because of a [recent change](https://github.com/rails/rails/pull/46817) in rails that requires rubygems to have a version of 3.3.13 or above. Because of this, bundler can't complete installing dependencies and tests fail.

> rails-7.1.0.alpha requires rubygems version >= 3.3.13, which is
> incompatible with the current version, 3.2.33

Bumping the version of rubygems in CI following the [documentation](https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby#rubygems) from [setup-ruby action](https://github.com/ruby/setup-ruby) allows all tests to complete successfully.

Failing test run: https://github.com/Shopify/memcached_store/actions/runs/4138445456/jobs/7154973741
<img width="1481" alt="Screenshot 2023-02-09 at 5 12 13 PM" src="https://user-images.githubusercontent.com/7518190/217951138-6b1a3dc5-f3d3-46a4-8bce-f38ff1a98102.png">
