### PR TITLE
Suppress deprecation warnings on Rails edge

### DIFF
--- a/lib/active_support/cache/memcached_store.rb
+++ b/lib/active_support/cache/memcached_store.rb
@@ -67,7 +67,13 @@ module ActiveSupport
         @swallow_exceptions = true
         @swallow_exceptions = options.delete(:swallow_exceptions) if options.key?(:swallow_exceptions)
 
-        super(options)
+        if options.key?(:coder)
+          raise ArgumentError, "ActiveSupport::Cache::MemcachedStore doesn't support custom coders"
+        end
+
+        # We don't use a coder, so we set it to nil so Active Support don't think we're using
+        # a deprecated one.
+        super(options.merge(coder: nil))
 
         if addresses.first.is_a?(Memcached)
           @connection = addresses.first

--- a/lib/memcached_store/version.rb
+++ b/lib/memcached_store/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module MemcachedStore
-  VERSION = "2.3.1"
+  VERSION = "2.3.2"
 end


### PR DESCRIPTION
Fixes:

```
DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.

Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
for more information on how to upgrade.
 (called from initialize at /tmp/bundle/ruby/3.2.0/gems/memcached_store-2.3.1/lib/active_support/cache/memcached_store.rb:70)
```